### PR TITLE
Make tool_consumer_instance_guid optional

### DIFF
--- a/src/ToolProvider/ToolProvider.php
+++ b/src/ToolProvider/ToolProvider.php
@@ -808,11 +808,6 @@ EOD;
                         if (!$this->ok) {
                             $this->reason = 'Request is from an invalid tool consumer.';
                         }
-                    } else {
-                        $this->ok = isset($_POST['tool_consumer_instance_guid']);
-                        if (!$this->ok) {
-                            $this->reason = 'A tool consumer GUID must be included in the launch request.';
-                        }
                     }
                 }
                 if ($this->ok) {


### PR DESCRIPTION
In the specification, tool_consumer_instance_guid is only listed as recommended. https://www.imsglobal.org/specs/ltiv2p0/implementation-guide#toc-42 - however the library was requiring it.
Fix for issue #19